### PR TITLE
Refactor: clone, perms, composer, tags...

### DIFF
--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -1,7 +1,13 @@
 ---
+
+# Remove app folder first, for a "clean" clone
+- name: remove the app folder if present
+  file: 
+    path: "{{ app_base_path }}/{{ item.key }}" 
+    state: absent
+  with_dict: "{{ apps }}"
+
 - name: clone apps
-  become: yes
-  become_user: "{{ app_deploy_user }}"
   git:
     repo: "{{ item.value.src | mandatory }}"
     depth: 1
@@ -11,31 +17,23 @@
     update: yes
     force: yes
   with_dict: "{{ apps }}"
-  tags: 
-    - bedita-apps
 
 - include_tasks: instance.yml
   with_dict: "{{ apps }}"
   loop_control:
     loop_var: app
 
+- name: copy composer.lock (optional)
+  template:
+    src: "{{ app_templates_path }}/composer/{{ item.key }}/composer.lock"
+    dest: "{{ item.value.deploy_path }}/composer.lock"
+  when: (app_templates_path + '/composer/' + item.key + '/composer.lock') is is_file
+  with_dict: "{{ apps }}"
+
 - name: install apps dependencies (composer)
-  become: yes
-  become_user: "{{ app_deploy_user }}"
   composer:
     command: install
     prefer_dist: yes
     working_dir: "{{ app_base_path }}/{{ item.key }}"
   with_dict: "{{ apps }}"
-  tags: bedita-dependencies
 
-
-- name: update apps dependencies (composer)
-  become: yes
-  become_user: "{{ app_deploy_user }}"
-  composer:
-    command: update
-    prefer_dist: yes
-    working_dir: "{{ app_base_path }}/{{ item.key }}"
-  with_dict: "{{ apps }}"
-  tags: bedita-dependencies

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,26 +1,19 @@
 ---
 - name: install css/js packages
-  become_user: "{{ app_deploy_user }}"
   command: yarn
   args:
     chdir: "{{ app_base_path }}/{{ item.key }}"
   when: item.value.bundle is defined
   with_dict: "{{ apps }}"
-  tags:
-    - bedita-package
 
 - name: create JS/CSS bundle
-  become_user: "{{ app_deploy_user }}"
   command: yarn build
   args:
     chdir: "{{ app_base_path }}/{{ item.key }}"
   when: item.value.bundle is defined
   with_dict: "{{ apps }}"
-  tags:
-    - bedita-package
 
 - name: create package archive
-  become_user: "{{ app_deploy_user }}"
   archive:
     path:
     - "{{ app_base_path }}/{{ item.key }}/*"
@@ -34,8 +27,6 @@
     owner: "{{ app_deploy_user }}"
     format: gz
   with_dict: "{{ apps }}"
-  tags:
-    - bedita-package
 
 - name: fetch package 
   fetch:
@@ -43,5 +34,3 @@
     dest: "tmp/packages/{{ item.key }}-{{ pack_suffix }}.tar.gz"
     flat: yes
   with_dict: "{{ apps }}"
-  tags:
-    - bedita-package

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,7 +1,5 @@
 ---
 - name: clone plugins via git
-  become: yes
-  become_user: "{{ app_deploy_user }}"
   git:
     repo: "{{ plugin.value.src }}"
     version: "{{ plugin.value.version }}"
@@ -10,5 +8,3 @@
     update: yes
     force: yes
   with_dict: "{{ plugin }}"
-  tags: 
-    - bedita-apps

--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,20 +1,7 @@
 ---
 - name: set up composer github auth token
-  become: yes
-  become_user: "{{ app_deploy_user }}"
   command: "composer global config github-oauth.github.com {{ app_composer_github_token }}"
   when: app_composer_github_token | default("") != ""
-  tags: composer
-
-- name: ensure target directory exists and has correct permissions set
-  become: yes
-  file:
-    path: "{{ app_base_path }}/{{ item.key }}"
-    state: directory
-    owner: "{{ app_deploy_user }}"
-    mode: 0755
-  with_dict: "{{ apps }}"
-  tags: bedita
 
 - name: ensure app `logs` directory exists
   become: yes
@@ -25,7 +12,6 @@
     owner: "{{ app_deploy_user }}"
     mode: 0755
   with_dict: "{{ apps }}"
-  tags: bedita
 
 - name: ensure app `tmp` directory exists
   become: yes
@@ -36,4 +22,3 @@
     owner: "{{ app_deploy_user }}"
     mode: 0755
   with_dict: "{{ apps }}"
-  tags: bedita


### PR DESCRIPTION
Changes in this PR:

- cleanup app folder before `clone` - avoid unwanted file presence from a previous clone/deploy action
- remove `become` and `become_user`, should be set in `roles` definition in playbook
- remove `tags`, not interesting in this context 
- new (optional) task to add `composer.lock` from playbook