### PR TITLE
Use hirak/prestissimo package

### DIFF
--- a/tasks/clone.yml
+++ b/tasks/clone.yml
@@ -53,6 +53,13 @@
   when: (app_templates_path + '/composer/' + item.key + '/composer.lock') is is_file
   with_dict: "{{ apps }}"
 
+- name: install hirak/prestissimo (composer)
+  composer:
+    command: require
+    arguments: hirak/prestissimo
+    prefer_dist: yes
+    global_command: yes
+
 - name: install apps dependencies (composer)
   composer:
     command: install


### PR DESCRIPTION
This PR adds hirak/prestissimo.

The package allows to parallelize `composer install`, granting a huge speedup.

The same functionality should be introduced with composer 2.0, which is currently in alpha.